### PR TITLE
Added minVersion to mixin

### DIFF
--- a/Common/src/main/resources/mavapi.mixins.json
+++ b/Common/src/main/resources/mavapi.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "io.github.akashiikun.mavapi.v1.impl.mixin",
+  "minVersion": "0.8",
   "compatibilityLevel": "JAVA_17",
   "client": [
     "AxolotlEntityRendererMixin"


### PR DESCRIPTION
I added the minVersion property to the mixin to fix this error:
```
[main/ERROR]: Mixin config forge-mavapi.mixins.json does not specify "minVersion" property
```
